### PR TITLE
add simple .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.2
+  - 1.3
+  - tip
+
+script: go test .


### PR DESCRIPTION
This commit adds a simple .travis.yml file for Travis CI configuration. The
file should runs `go test` which will as of now, pass as there are no tests.

PR's should report as a success when this is merged instead of fail as it
currently does.

Thanks!